### PR TITLE
Split PyPI and test PyPI publishing into separate actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,15 +12,13 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Build distribution package
-      run: |
-        pip install twine wheel
-        pip wheel -w dist --no-deps .
     - name: Publish to PyPI
       if: startsWith(github.event.ref, 'refs/tags')
       env:
         TWINE_USERNAME: '__token__'
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
+        pip install twine wheel
+        pip wheel -w dist --no-deps .
         twine upload --skip-existing dist/*
       continue-on-error: true

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,9 @@
 name: Publish to PyPI and TestPyPI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build-and-publish:
@@ -17,7 +20,6 @@ jobs:
         pip install twine wheel
         pip wheel -w dist --no-deps .
     - name: Publish to Test PyPI
-      if: github.event.pull_request.merged == true
       env:
         TWINE_USERNAME: '__token__'
         TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
@@ -25,7 +27,7 @@ jobs:
         twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/*
       continue-on-error: true
     - name: Publish to PyPI
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      if: startsWith(github.event.ref, 'refs/tags')
       env:
         TWINE_USERNAME: '__token__'
         TWINE_PASSWORD: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,6 +5,7 @@ on: push
 jobs:
   build-and-publish:
     name: Publish to PyPI
+    if: startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
@@ -13,7 +14,6 @@ jobs:
       with:
         python-version: 3.7
     - name: Publish to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
       env:
         TWINE_USERNAME: '__token__'
         TWINE_PASSWORD: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,9 +1,6 @@
 name: Publish to PyPI and TestPyPI
 
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   build-and-publish:
@@ -20,6 +17,7 @@ jobs:
         pip install twine wheel
         pip wheel -w dist --no-deps .
     - name: Publish to Test PyPI
+      if: github.event.pull_request.merged == true
       env:
         TWINE_USERNAME: '__token__'
         TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
@@ -27,7 +25,7 @@ jobs:
         twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/*
       continue-on-error: true
     - name: Publish to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       env:
         TWINE_USERNAME: '__token__'
         TWINE_PASSWORD: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,10 +1,13 @@
-name: Publish to PyPI
+name: Publish to Test PyPI
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build-and-publish:
-    name: Publish to PyPI
+    name: Publish to Test PyPI
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
@@ -16,11 +19,10 @@ jobs:
       run: |
         pip install twine wheel
         pip wheel -w dist --no-deps .
-    - name: Publish to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
+    - name: Publish to Test PyPI
       env:
         TWINE_USERNAME: '__token__'
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+        TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
       run: |
-        twine upload --skip-existing dist/*
+        twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/*
       continue-on-error: true

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -15,14 +15,12 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Build distribution package
-      run: |
-        pip install twine wheel
-        pip wheel -w dist --no-deps .
     - name: Publish to Test PyPI
       env:
         TWINE_USERNAME: '__token__'
         TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
       run: |
+        pip install twine wheel
+        pip wheel -w dist --no-deps .
         twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/*
       continue-on-error: true


### PR DESCRIPTION
My Action in #7 deployed to Test PyPI just fine when merged to master, but I was not able to publish to PyPI from a tagged commit there. I hypothesize that this is because the Action didn't recognize the tag as being pushed to master. In this PR I've split the test and real PyPI publishing into 2 actions. It's redundant, but I believe will do what we want.