### PR TITLE
Exclude example repo from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include django_geomultiplechoice/templates *.txt *.html

--- a/README_pypi.md
+++ b/README_pypi.md
@@ -1,0 +1,9 @@
+# 🗺 GeoMultipleChoice
+
+A Django widget to select multiple geographic areas.
+
+![GeoMultipleChoice demo](https://raw.githubusercontent.com/datamade/django-geomultiplechoice/master/images/just-spaces.gif)
+
+Originally created by [@jeancochrane](https://github.com/jeancochrane). Packaged up by [@beamalsky](https://github.com/beamalsky). Both from [DataMade](https://datamade.us/).
+
+**For documentation of this widget, including an example implementation and guidelines for local development, view [the django-geomultiplechoice GitHub repo](https://github.com/datamade/django-geomultiplechoice).**

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,18 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README_pypi.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="django-geomultiplechoice",
-    version="0.0.3",
+    version="0.0.4",
     author="Bea Malsky",
     author_email="beamalsky@datamade.us",
     description="A Django widget to select multiple geographic areas",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/datamade//django-geomultiplechoice",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(include=['django_geomultiplechoice']),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,15 @@ with open("README_pypi.md", "r") as fh:
 
 setuptools.setup(
     name="django-geomultiplechoice",
-    version="0.0.4",
+    version="0.0.5",
     author="Bea Malsky",
     author_email="beamalsky@datamade.us",
     description="A Django widget to select multiple geographic areas",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/datamade//django-geomultiplechoice",
-    packages=setuptools.find_packages(include=['django_geomultiplechoice']),
+    packages=['django_geomultiplechoice'],
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR limits packaging to the `django_geomultiplechoice` directory in this repo. At first I tried to exclude `example` with the line below, but it still included the migrations in that folder.

```bash
packages=setuptools.find_packages(include=['django_geomultiplechoice']),
```

Not the behavior I'd expect! As far as I can tell, using `include` gets us where we want.

This PR also modifies the README on pypi to link back to this repo. I considered writing a different, package-specific README as Forest suggested in #11. However, since using this widget involves writing a custom model and a fairly involved form setup I think it would be better to keep the documentation all in one place.